### PR TITLE
use signature from AdminExtensionInterface

### DIFF
--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -359,10 +359,8 @@ You can add custom items to the actions menu for a specific action by overriding
 
 .. code-block:: php
 
-    public function configureActionButtons($action, $object = null)
+    public function configureActionButtons(AdminInterface $admin, $list, $action, $object)
     {
-        $list = parent::configureActionButtons($action, $object);
-
         if (in_array($action, array('show', 'edit', 'acl')) && $object) {
             $list['custom'] = array(
                 'template' => 'AppBundle:Button:custom_button.html.twig',


### PR DESCRIPTION
## Changelog

### Changed

documentation about adding custom items to the actions menu

## Subject

signature of method in doc is not the same as in AdminExtensionInterface and AbstractAdminExtension. So example before my change in the doc will not work.